### PR TITLE
Remove spellcheck from reviewdog workflow

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -11,17 +11,6 @@ jobs:
         uses: reviewdog/action-shellcheck@v1
         with:
           github_token: ${{ secrets.github_token }}
-  # Use misspell to correct spelling mistakes
-  misspell:
-    name: runner / misspell
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: misspell
-        uses: reviewdog/action-misspell@v1
-        with:
-          github_token: ${{ secrets.github_token }}
-          locale: "US"
   # Use yamllint to lint yaml files
   yamllint:
     name: check / yamllint


### PR DESCRIPTION
We're uncomfortable with the idea of a spellcheck in this context, removing.