### PR TITLE
configure shellcheck reviewdog job to fail on error

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -12,6 +12,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
+          fail_on_error: true
   # Use yamllint to lint yaml files
   yamllint:
     name: check / yamllint


### PR DESCRIPTION
like the other reviewdog jobs, shellcheck needs to also fail on error